### PR TITLE
packages/wpan-tools: distribute wpan-ping binary in wpan-tools package

### DIFF
--- a/package/network/utils/wpan-tools/Makefile
+++ b/package/network/utils/wpan-tools/Makefile
@@ -31,6 +31,7 @@ endef
 define Package/wpan-tools/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/iwpan $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wpan-ping/wpan-ping $(1)/usr/sbin/
 endef
 
 $(eval $(call BuildPackage,wpan-tools))


### PR DESCRIPTION
The wpan-ping utility is useful for testing and debugging a plain ieee 802.15.4
connection without any 6LoWPAN involved.

Signed-off-by: Stefan Schmidt <stefan@datenfreihafen.org>