### PR TITLE
pistachio_marduk_ca8210.dts: add extclock-enable

### DIFF
--- a/target/linux/pistachio/dts/pistachio_marduk_ca8210.dts
+++ b/target/linux/pistachio/dts/pistachio_marduk_ca8210.dts
@@ -39,6 +39,7 @@
 		spi-cpol;
 		reset-gpio = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 		irq-gpio = <&gpio2 12 GPIO_ACTIVE_HIGH>;
+		extclock-enable;
 		extclock-freq = <16000000>;
 		extclock-gpio = <2>;
 	};


### PR DESCRIPTION
since updated cascoda ca8210-linux driver needs to be specified to enable the ext-clock.

Signed-off-by: Abhijit Mahajani Abhijit.Mahajani@imgtec.com
