### PR TITLE
creator default configs: Remove ssl support for wget in busybox 

### DIFF
--- a/target/linux/pistachio/creator-platform-all-cascoda.config
+++ b/target/linux/pistachio/creator-platform-all-cascoda.config
@@ -1,8 +1,6 @@
 CONFIG_TARGET_pistachio=y
 CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_ca8210=y
-CONFIG_BUSYBOX_CUSTOM=y
-CONFIG_BUSYBOX_CONFIG_FEATURE_WGET_OPENSSL=y
 CONFIG_PACKAGE_uboot-pistachio_marduk=y
 CONFIG_ALL=y
 CONFIG_IB=y
@@ -14,7 +12,7 @@ CONFIG_LOCALMIRROR="https://downloads.creatordev.io/pistachio/marduk/dl"
 CONFIG_OPENSSL_WITH_EC=y
 CONFIG_PACKAGE_ca-certificates=y
 CONFIG_PACKAGE_libopenssl=y
-CONFIG_PACKAGE_openssl-util=y
+CONFIG_PACKAGE_libustream-openssl=y
 CONFIG_PACKAGE_opkg-smime=y
 # CONFIG_PACKAGE_usign is not set
 CONFIG_PACKAGE_zlib=y

--- a/target/linux/pistachio/creator-platform-all.config
+++ b/target/linux/pistachio/creator-platform-all.config
@@ -1,8 +1,6 @@
 CONFIG_TARGET_pistachio=y
 CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_cc2520=y
-CONFIG_BUSYBOX_CUSTOM=y
-CONFIG_BUSYBOX_CONFIG_FEATURE_WGET_OPENSSL=y
 CONFIG_PACKAGE_uboot-pistachio_marduk=y
 CONFIG_ALL=y
 CONFIG_IB=y
@@ -14,7 +12,7 @@ CONFIG_LOCALMIRROR="https://downloads.creatordev.io/pistachio/marduk/dl"
 CONFIG_OPENSSL_WITH_EC=y
 CONFIG_PACKAGE_ca-certificates=y
 CONFIG_PACKAGE_libopenssl=y
-CONFIG_PACKAGE_openssl-util=y
+CONFIG_PACKAGE_libustream-openssl=y
 CONFIG_PACKAGE_opkg-smime=y
 # CONFIG_PACKAGE_usign is not set
 CONFIG_PACKAGE_zlib=y

--- a/target/linux/pistachio/creator-platform-default-cascoda.config
+++ b/target/linux/pistachio/creator-platform-default-cascoda.config
@@ -1,14 +1,12 @@
 CONFIG_TARGET_pistachio=y
 CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_ca8210=y
-CONFIG_BUSYBOX_CUSTOM=y
-CONFIG_BUSYBOX_CONFIG_FEATURE_WGET_OPENSSL=y
 CONFIG_IMAGEOPT=y
 CONFIG_LOCALMIRROR="https://downloads.creatordev.io/pistachio/marduk/dl"
 CONFIG_OPENSSL_WITH_EC=y
 CONFIG_PACKAGE_ca-certificates=y
 CONFIG_PACKAGE_libopenssl=y
-CONFIG_PACKAGE_openssl-util=y
+CONFIG_PACKAGE_libustream-openssl=y
 CONFIG_PACKAGE_opkg-smime=y
 # CONFIG_PACKAGE_usign is not set
 CONFIG_PACKAGE_zlib=y

--- a/target/linux/pistachio/creator-platform-default.config
+++ b/target/linux/pistachio/creator-platform-default.config
@@ -1,14 +1,12 @@
 CONFIG_TARGET_pistachio=y
 CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_cc2520=y
-CONFIG_BUSYBOX_CUSTOM=y
-CONFIG_BUSYBOX_CONFIG_FEATURE_WGET_OPENSSL=y
 CONFIG_IMAGEOPT=y
 CONFIG_LOCALMIRROR="https://downloads.creatordev.io/pistachio/marduk/dl"
 CONFIG_OPENSSL_WITH_EC=y
 CONFIG_PACKAGE_ca-certificates=y
 CONFIG_PACKAGE_libopenssl=y
-CONFIG_PACKAGE_openssl-util=y
+CONFIG_PACKAGE_libustream-openssl=y
 CONFIG_PACKAGE_opkg-smime=y
 # CONFIG_PACKAGE_usign is not set
 CONFIG_PACKAGE_zlib=y


### PR DESCRIPTION
1. Enable libustream-openssl, required for uclient-fetch
2. Removed ssl support enabled for wget in busybox

Signed-off-by: Avinash Tahakik avinashtahakik@gmail.com
