### PR TITLE
feeds.conf.default: Change openwrt-feeds to Ci40-platform-feed

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -4,7 +4,7 @@ src-git routing https://github.com/openwrt-routing/packages.git
 src-git telephony https://github.com/openwrt/telephony.git
 src-git management https://github.com/openwrt-management/packages.git
 src-git targets https://github.com/openwrt/targets.git
-src-git pkg https://github.com/CreatorDev/openwrt-feeds.git
+src-git ci40 https://github.com/CreatorDev/Ci40-platform-feed.git
 src-git ckt https://github.com/CreatorKit/openwrt-ckt-feeds.git
 #src-git oldpackages http://git.openwrt.org/packages.git
 #src-link custom /usr/src/openwrt/custom-feed


### PR DESCRIPTION
Signed-off-by: Nikhil Zinjurde nikhil.zinjurde@imgtec.com
