### PR TITLE
Workaround: replace opkg by opkg-smime in target.mk

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -12,7 +12,7 @@ __target_inc=1
 DEVICE_TYPE?=router
 
 # Default packages - the really basic set
-DEFAULT_PACKAGES:=base-files libc libgcc busybox dropbear mtd uci opkg netifd fstools uclient-fetch logd
+DEFAULT_PACKAGES:=base-files libc libgcc busybox dropbear mtd uci opkg-smime netifd fstools uclient-fetch logd
 # For nas targets
 DEFAULT_PACKAGES.nas:=block-mount fdisk lsblk mdadm
 # For router targets


### PR DESCRIPTION
Since opkg is disabled in creator platform default configs and
opkg-smime has been used instead, it needs to be chnaged in DEFAULT_PACKAGES
as well, else ImageBuilder fails to compile by complaining about missing opkg.

Although this is not suitable for upstreaming, once we understand
how to make opkg and opkg-smime live together and still install opkg-smime's opkg.conf on the target,
we can remove this commit.

Signed-off-by: Abhijit Mahajani Abhijit.Mahajani@imgtec.com
