### PR TITLE
uboot-envtools: add pistachio support

### DIFF
--- a/package/boot/uboot-envtools/Makefile
+++ b/package/boot/uboot-envtools/Makefile
@@ -105,6 +105,10 @@ ifneq ($(CONFIG_TARGET_oxnas),)
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/oxnas $(1)/etc/uci-defaults/30_uboot-envtools
 endif
+ifneq ($(CONFIG_TARGET_pistachio),)
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DATA) ./files/pistachio $(1)/etc/uci-defaults/30_uboot-envtools
+endif
 ifneq ($(CONFIG_TARGET_ramips),)
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_DATA) ./files/ramips $(1)/etc/uci-defaults/30_uboot-envtools

--- a/package/boot/uboot-envtools/files/pistachio
+++ b/package/boot/uboot-envtools/files/pistachio
@@ -1,4 +1,10 @@
 #!/bin/sh
+#
+# Copyright (C) 2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
 
 [ -e /etc/config/ubootenv ] && exit 0
 


### PR DESCRIPTION
Remove 30_uboot-envtools from target/linux/pistachio to proper location.

Signed-off-by: Abhijit Mahajani Abhijit.Mahajani@imgtec.com
