### PR TITLE
pistachio/wireless: remove ap mode from wifi config.

### DIFF
--- a/target/linux/pistachio/base-files/etc/uci-defaults/config/wireless
+++ b/target/linux/pistachio/base-files/etc/uci-defaults/config/wireless
@@ -4,10 +4,3 @@ config wifi-device  radio0
         option hwmode   11g
         option path     'virtual/uccp420/uccwlan'
         option htmode   'none'
-
-config wifi-iface 'ap'
-        option device 'radio0'
-        option network 'ap'
-        option mode 'ap'
-        option ssid 'CreatorAP'
-        option encryption 'none'


### PR DESCRIPTION
Signed-off-by: Manohar Narkhede Manohar.Narkhede@imgtec.com
