### PR TITLE
travis.yml: revert device-tree-compiler hack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 sudo: false
 language: c
 
-addons:
-  apt:
-    packages:
-    - device-tree-compiler
-
 before_install:
     - export CXXFLAGS="$CXXFLAGS -fPIC"
 


### PR DESCRIPTION
since it has been added properly via https://github.com/travis-ci/apt-package-whitelist/pull/3388

Signed-off-by: Abhijit Mahajani Abhijit.Mahajani@imgtec.com
